### PR TITLE
Added support for Mac OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ func main() {
 ```
 ## Testing
 
-### Linux
+### Linux and Mac OS
 - `socat -d -d pty,raw,echo=0 pty,raw,echo=0`
+- on Mac OS, the socat command can be installed using homebrew:
+	````brew install socat````
 
 ### Windows
 - [Null-modem emulator](http://com0com.sourceforge.net/)

--- a/serial_darwin.go
+++ b/serial_darwin.go
@@ -2,29 +2,280 @@ package serial
 
 import (
 	"fmt"
+	"log"
+	"os"
+	"syscall"
+	"time"
+	"unsafe"
 )
 
-var errNotImplemented = fmt.Errorf("not implemented")
-
-type port struct {
+var baudRates = map[int]uint64{
+	50:     syscall.B50,
+	75:     syscall.B75,
+	110:    syscall.B110,
+	134:    syscall.B134,
+	150:    syscall.B150,
+	200:    syscall.B200,
+	300:    syscall.B300,
+	600:    syscall.B600,
+	1200:   syscall.B1200,
+	1800:   syscall.B1800,
+	2400:   syscall.B2400,
+	4800:   syscall.B4800,
+	9600:   syscall.B9600,
+	19200:  syscall.B19200,
+	38400:  syscall.B38400,
+	57600:  syscall.B57600,
+	115200: syscall.B115200,
+	230400: syscall.B230400,
 }
 
+// ioctl constants
+const (
+	TCGETS = syscall.TIOCGETA
+	TCSETS = syscall.TIOCSETA
+)
+
+var charSizes = map[int]uint64{
+	5: syscall.CS5,
+	6: syscall.CS6,
+	7: syscall.CS7,
+	8: syscall.CS8,
+}
+
+// port implements Port interface.
+type port struct {
+	// Should use fd directly by using syscall.Open() ?
+	file       *os.File
+	oldTermios *syscall.Termios
+
+	timeout time.Duration
+}
+
+// New allocates and returns a new serial port controller.
 func New() Port {
 	return &port{}
 }
 
-func (_ *port) Open(*Config) error {
-	return errNotImplemented
+// Open connects to the given serial port.
+func (p *port) Open(c *Config) (err error) {
+	termios, err := newTermios(c)
+	if err != nil {
+		return
+	}
+	// See man termios(3).
+	// O_NOCTTY: no controlling terminal.
+	// O_NDELAY: no data carrier detect.
+	p.file, err = os.OpenFile(c.Address, syscall.O_RDWR|syscall.O_NOCTTY|syscall.O_NDELAY, os.FileMode(0666))
+	if err != nil {
+		return
+	}
+	// Backup current termios to restore on closing.
+	p.backupTermios()
+	if err = p.setTermios(termios); err != nil {
+		p.file.Close()
+		p.file = nil
+		p.oldTermios = nil
+		return
+	}
+	p.timeout = c.Timeout
+	return
 }
 
-func (_ *port) Read([]byte) (int, error) {
-	return 0, errNotImplemented
+func (p *port) Close() (err error) {
+	if p.file == nil {
+		return
+	}
+	p.restoreTermios()
+	err = p.file.Close()
+	p.file = nil
+	p.oldTermios = nil
+	return
 }
 
-func (_ *port) Write([]byte) (int, error) {
-	return 0, errNotImplemented
+// Read reads from serial port. Port must be opened before calling this method.
+// It is blocked until all data received or timeout after p.timeout.
+func (p *port) Read(b []byte) (n int, err error) {
+	var rfds syscall.FdSet
+
+	fd := int(p.file.Fd())
+	fdSet(fd, &rfds)
+
+	var tv *syscall.Timeval
+	if p.timeout > 0 {
+		timeout := syscall.NsecToTimeval(p.timeout.Nanoseconds())
+		tv = &timeout
+	}
+	if err = syscall.Select(fd+1, &rfds, nil, nil, tv); err != nil {
+		err = fmt.Errorf("serial: could not select: %v", err)
+		return
+	}
+	if !fdIsSet(fd, &rfds) {
+		// Timeout
+		err = ErrTimeout
+		return
+	}
+	n, err = p.file.Read(b)
+	return
 }
 
-func (_ *port) Close() error {
-	return errNotImplemented
+// Write writes data to the serial port.
+func (p *port) Write(b []byte) (n int, err error) {
+	n, err = p.file.Write(b)
+	return
+}
+
+func (p *port) setTermios(termios *syscall.Termios) (err error) {
+	if err = tcsetattr(int(p.file.Fd()), termios); err != nil {
+		err = fmt.Errorf("serial: could not set setting: %v", err)
+	}
+	return
+}
+
+// backupTermios saves current termios setting.
+// Make sure that device file has been opened before calling this function.
+func (p *port) backupTermios() {
+	oldTermios := &syscall.Termios{}
+	if err := tcgetattr(int(p.file.Fd()), oldTermios); err != nil {
+		// Warning only.
+		log.Printf("serial: could not get setting: %v\n", err)
+		return
+	}
+	// Will be reloaded when closing.
+	p.oldTermios = oldTermios
+}
+
+// restoreTermios restores backed up termios setting.
+// Make sure that device file has been opened before calling this function.
+func (p *port) restoreTermios() {
+	if p.oldTermios == nil {
+		return
+	}
+	if err := tcsetattr(int(p.file.Fd()), p.oldTermios); err != nil {
+		// Warning only.
+		log.Printf("serial: could not restore setting: %v\n", err)
+		return
+	}
+	p.oldTermios = nil
+}
+
+// Helpers for termios
+
+func newTermios(c *Config) (termios *syscall.Termios, err error) {
+	termios = &syscall.Termios{}
+	var flag uint64
+	// Baud rate
+	if c.BaudRate == 0 {
+		// 19200 is the required default.
+		flag = syscall.B19200
+	} else {
+		flag = baudRates[c.BaudRate]
+		if flag == 0 {
+			err = fmt.Errorf("serial: unsupported baud rate %v", c.BaudRate)
+			return
+		}
+	}
+	// Input baud.
+	termios.Ispeed = flag
+	// Output baud.
+	termios.Ospeed = flag
+	// Character size.
+	if c.DataBits == 0 {
+		flag = syscall.CS8
+	} else {
+		flag = charSizes[c.DataBits]
+		if flag == 0 {
+			err = fmt.Errorf("serial: unsupported character size %v", c.DataBits)
+			return
+		}
+	}
+	termios.Cflag |= flag
+	// Stop bits
+	switch c.StopBits {
+	case 0, 1:
+		// Default is one stop bit.
+		// noop
+	case 2:
+		// CSTOPB: Set two stop bits.
+		termios.Cflag |= syscall.CSTOPB
+	default:
+		err = fmt.Errorf("serial: unsupported stop bits %v", c.StopBits)
+		return
+	}
+	switch c.Parity {
+	case "N":
+		// noop
+	case "O":
+		// PARODD: Parity is odd.
+		termios.Cflag |= syscall.PARODD
+		fallthrough
+	case "", "E":
+		// As mentioned in the modbus spec, the default parity mode must be Even parity
+		// PARENB: Enable parity generation on output.
+		termios.Cflag |= syscall.PARENB
+		// INPCK: Enable input parity checking.
+		termios.Iflag |= syscall.INPCK
+	default:
+		err = fmt.Errorf("serial: unsupported parity %v", c.Parity)
+		return
+	}
+	// Control modes.
+	// CREAD: Enable receiver.
+	// CLOCAL: Ignore control lines.
+	termios.Cflag |= syscall.CREAD | syscall.CLOCAL
+	// Special characters.
+	// VMIN: Minimum number of characters for noncanonical read.
+	// VTIME: Time in deciseconds for noncanonical read.
+	// Both are unused as NDELAY is we utilized when opening device.
+	return
+}
+
+// tcsetattr sets terminal file descriptor parameters.
+// See man tcsetattr(3).
+func tcsetattr(fd int, termios *syscall.Termios) (err error) {
+	r, _, errno := syscall.Syscall(uintptr(syscall.SYS_IOCTL),
+		uintptr(fd), uintptr(TCSETS), uintptr(unsafe.Pointer(termios)))
+	if errno != 0 {
+		err = errno
+		return
+	}
+	if r != 0 {
+		err = fmt.Errorf("tcsetattr failed %v", r)
+	}
+	return
+}
+
+// tcgetattr gets terminal file descriptor parameters.
+// See man tcgetattr(3).
+func tcgetattr(fd int, termios *syscall.Termios) (err error) {
+	r, _, errno := syscall.Syscall(uintptr(syscall.SYS_IOCTL),
+		uintptr(fd), uintptr(TCGETS), uintptr(unsafe.Pointer(termios)))
+	if errno != 0 {
+		err = errno
+		return
+	}
+	if r != 0 {
+		err = fmt.Errorf("tcgetattr failed %v", r)
+		return
+	}
+	return
+}
+
+// fdGet returns index and offset of fd in fds.
+func fdGet(fd int, fds *syscall.FdSet) (index, offset int) {
+	index = fd / (syscall.FD_SETSIZE / len(fds.Bits)) % len(fds.Bits)
+	offset = fd % (syscall.FD_SETSIZE / len(fds.Bits))
+	return
+}
+
+// fdSet implements FD_SET macro.
+func fdSet(fd int, fds *syscall.FdSet) {
+	idx, pos := fdGet(fd, fds)
+	fds.Bits[idx] = 1 << uint(pos)
+}
+
+// fdIsSet implements FD_ISSET macro.
+func fdIsSet(fd int, fds *syscall.FdSet) bool {
+	idx, pos := fdGet(fd, fds)
+	return fds.Bits[idx]&(1<<uint(pos)) != 0
 }

--- a/serial_test.go
+++ b/serial_test.go
@@ -7,8 +7,8 @@ import (
 
 const (
 	// socat -d -d pty,raw,echo=0 pty,raw,echo=0
-	pty1 = "/dev/pts/5"
-	pty2 = "/dev/pts/6"
+	pty1 = "/dev/ttys009"
+	pty2 = "/dev/ttys010"
 )
 
 func TestReadWrite(t *testing.T) {


### PR DESCRIPTION
Hi,

the pull request contains an implementation of the serial code for mac os. Basically I just took the linux code and changed some minor details:

 - Some Baudrates are not defined on Mac OS, so I removed them They're baudrates above 115200 baud which I did not encounter in real life so far.
 - The definitions for TCGETS and TCSETS differ.
 - Minor adjustments such as replacing uint32 w/ uint64

I also changed the test code to use different PTYs. This is probably not what is reasonable - the testcode depends on the runtime system (since it depends on PTY names). Probably you could refactor the test to use environment variables, but this decision is up to you.

The testsuite works, as well as my small test program for getting values from a SDM630 smart meter. I use ````socat ```` just like under linux for running the testsuite.

-Mathias