### PR TITLE
Fixed cross compilation on MIPS architecture

### DIFF
--- a/serial_posix.go
+++ b/serial_posix.go
@@ -173,11 +173,9 @@ func newTermios(c *Config) (termios *syscall.Termios, err error) {
 	}
 	termios.Cflag |= flag
 	// Input baud.
-	//termios.Ispeed = flag
-	cfSetIspeed(termios, uint64(flag))
+	cfSetIspeed(termios, flag)
 	// Output baud.
-	//termios.Ospeed = flag
-	cfSetOspeed(termios, uint64(flag))
+	cfSetOspeed(termios, flag)
 	// Character size.
 	if c.DataBits == 0 {
 		flag = syscall.CS8

--- a/serial_posix.go
+++ b/serial_posix.go
@@ -173,9 +173,11 @@ func newTermios(c *Config) (termios *syscall.Termios, err error) {
 	}
 	termios.Cflag |= flag
 	// Input baud.
-	termios.Ispeed = flag
+	//termios.Ispeed = flag
+	cfSetIspeed(termios, uint64(flag))
 	// Output baud.
-	termios.Ospeed = flag
+	//termios.Ospeed = flag
+	cfSetOspeed(termios, uint64(flag))
 	// Character size.
 	if c.DataBits == 0 {
 		flag = syscall.CS8

--- a/termios_bsd.go
+++ b/termios_bsd.go
@@ -1,5 +1,4 @@
-// +build linux
-// +build mips mipsle mips64 mips64le
+// +build freebsd openbsd netbsd
 
 package serial
 
@@ -8,9 +7,9 @@ import (
 )
 
 func cfSetIspeed(termios *syscall.Termios, speed uint32) {
-	// MIPS has no Ispeed field in termios.
+	termios.Ispeed = speed
 }
 
 func cfSetOspeed(termios *syscall.Termios, speed uint32) {
-	// MIPS has no Ospeed field in termios.
+	termios.Ospeed = speed
 }

--- a/termios_darwin.go
+++ b/termios_darwin.go
@@ -1,5 +1,3 @@
-// +build !mips,!mipsle,!mips64,!mips64le
-
 package serial
 
 import (

--- a/termios_linux.go
+++ b/termios_linux.go
@@ -1,5 +1,4 @@
-// +build linux
-// +build mips mipsle mips64 mips64le
+// +build !mips,!mipsle,!mips64,!mips64le
 
 package serial
 
@@ -8,9 +7,9 @@ import (
 )
 
 func cfSetIspeed(termios *syscall.Termios, speed uint32) {
-	// MIPS has no Ispeed field in termios.
+	termios.Ispeed = speed
 }
 
 func cfSetOspeed(termios *syscall.Termios, speed uint32) {
-	// MIPS has no Ospeed field in termios.
+	termios.Ospeed = speed
 }

--- a/termios_mipsx.go
+++ b/termios_mipsx.go
@@ -1,0 +1,15 @@
+// +build mips mipsle mips64 mips64le
+
+package serial
+
+import (
+	"syscall"
+)
+
+func cfSetIspeed(termios *syscall.Termios, speed uint64) {
+	// no op
+}
+
+func cfSetOspeed(termios *syscall.Termios, speed uint64) {
+	// no op
+}

--- a/termios_posix.go
+++ b/termios_posix.go
@@ -1,0 +1,15 @@
+// +build !mips,!mipsle,!mips64,!mips64le
+
+package serial
+
+import (
+	"syscall"
+)
+
+func cfSetIspeed(termios *syscall.Termios, speed uint64) {
+	termios.Ispeed = speed
+}
+
+func cfSetOspeed(termios *syscall.Termios, speed uint64) {
+	termios.Ospeed = speed
+}


### PR DESCRIPTION
This is to support compilation on MIPS-based hardware (e.g. OpenWRT). On MIPS, the `Termios` struct does not have the `Ispeed` and `Ospeed` fields. Use a set of wrapper functions to work around.