### PR TITLE
"System cannot find the file specified" when the port Address number is greater than 10

### DIFF
--- a/serial_windows.go
+++ b/serial_windows.go
@@ -156,13 +156,17 @@ func (p *port) setSerialConfig(c *Config) error {
 }
 
 func newHandle(c *Config) (handle syscall.Handle, err error) {
+	name := c.Address
+	if len(name) > 0 && name[0] != '\\' {
+		name = "\\\\.\\" + name
+	}
 	handle, err = syscall.CreateFile(
-		syscall.StringToUTF16Ptr(c.Address),
+		syscall.StringToUTF16Ptr(name),
 		syscall.GENERIC_READ|syscall.GENERIC_WRITE,
-		0,   // mode
-		nil, // security
+		0,                     // mode
+		nil,                   // security
 		syscall.OPEN_EXISTING, // create mode
-		0, // attributes
-		0) // templates
+		0,                     // attributes
+		0)                     // templates
 	return
 }


### PR DESCRIPTION
When the port Address number was greater, windows responded with the error "System cannot find the file specified".
The solution to this problem is adding some back slashes to the port Address,
other libraries are using this method. I already tested and my problem was solved

(Formatting was done via the golang format tool)

Thanks