### PR TITLE
add rs485 alternative RTS control function.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/jifanchn/serial
+
+go 1.14
+
+require (
+	github.com/pkg/term v0.0.0-20200520122047-c3ffed290a03
+	golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae // indirect
+)

--- a/serial.go
+++ b/serial.go
@@ -37,6 +37,8 @@ type Config struct {
 type RS485Config struct {
 	// Enable RS485 support
 	Enabled bool
+	// Use RS485 Alternative Operation, directly handle RTS pin via ioctl
+	RS485Alternative bool
 	// Delay RTS prior to send
 	DelayRtsBeforeSend time.Duration
 	// Delay RTS after send


### PR DESCRIPTION
Some embedded devices don't support full functional CTS/RTS RS485 hardware flow control in linux driver, especially when hardware flow control pins are not connected to device IP cores assigned pins.

But they do support one RTS enable pin, and they can send data when RTS is enabled and receive data when RTS is disabled.

For example, like MYD-YA157C development board:

![image](https://user-images.githubusercontent.com/16083781/88027401-c5dfbb00-cb69-11ea-9305-56c8d48190ae.png)

RS485 send function is enabled when PC6 is high and receive function is enabled when PC6 is low.

We can configure PC6 to be a RTS pin in device tree in serial port and enable/disable it via IOCTL.

Test results are shown:

![tek00000](https://user-images.githubusercontent.com/16083781/88026872-11de3000-cb69-11ea-9bb3-b4d3969214ab.png)

Similar function is also implemented in pySerial:

see RS485.write

https://github.com/pyserial/pyserial/blob/2d879b2428dacf30d5c8ba077626236b06c7d77f/serial/rs485.py
